### PR TITLE
Add gauge for the mail error queue size

### DIFF
--- a/src/main/java/ru/andreymarkelov/atlas/plugins/promjiraexporter/service/MetricCollectorImpl.java
+++ b/src/main/java/ru/andreymarkelov/atlas/plugins/promjiraexporter/service/MetricCollectorImpl.java
@@ -90,6 +90,11 @@ public class MetricCollectorImpl extends Collector implements MetricCollector, D
             .help("Mail Queue Gauge")
             .create();
 
+    private final Gauge mailQueueErrorGauge = Gauge.build()
+            .name("jira_mail_queue_error_gauge")
+            .help("Mail Queue Error Gauge")
+            .create();
+
     private final Gauge maintenanceExpiryDaysGauge = Gauge.build()
             .name("jira_maintenance_expiry_days_gauge")
             .help("Maintenance Expiry Days Gauge")
@@ -382,6 +387,7 @@ public class MetricCollectorImpl extends Collector implements MetricCollector, D
 
         // mail
         mailQueueGauge.set(mailQueue.size());
+        mailQueueErrorGauge.set(mailQueue.errorSize());
 
         // collect all metrics
         List<MetricFamilySamples> result = new ArrayList<>();
@@ -415,6 +421,7 @@ public class MetricCollectorImpl extends Collector implements MetricCollector, D
         result.addAll(httpSessionObjectsGauge.collect());
         result.addAll(jvmUptimeGauge.collect());
         result.addAll(mailQueueGauge.collect());
+        result.addAll(mailQueueErrorGauge.collect());
 
         return result;
     }


### PR DESCRIPTION
The MailQueue class exposes the size of the error queue via the
method #errorSize(). This PR exposes that value for Prometheus,
similar to the existing gauge for the mail queue size.