### PR TITLE
Jira uptime panel cannot evaluate metric when jvm_uptime_gauge returns multiple series

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -968,7 +968,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "jvm_uptime_gauge",
+              "expr": "jvm_uptime_gauge{job=\"jira\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"


### PR DESCRIPTION
This fixes the Jira uptime panel in the Jira dashboard when you have both the Jira and Confluence exporters being scraped by Prometheus. The panel shows "N/A" without the `{job="jira"}` because `jvm_uptime_gauge` returns multiple values since it doesn't have priority to pick the Jira/Confluence job as such:


```
jvm_uptime_gauge{instance="jira.foobar.com:443",job="jira"} | 2801419849
jvm_uptime_gauge{instance="confluence.foobar.com:443",job="confluence"} | 13649996585
```
Rendering: 
![](https://i.imgur.com/y4QV5dP.png)

Adding the `{job="jira"}` fixes this issue, as the Confluence dashboard already has this job label set for itself so it is not affected.
