### PR TITLE
Change Jira case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Standardize product case to Jira to align with [Atlassian branding changes](https://community.atlassian.com/t5/Feedback-Forum-articles/A-new-look-for-Atlassian/ba-p/638077)
+
 ## [1.0.33-jira8] (v8.x - 8.7.x)
 - Fix Fogue dependency
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
-# Prometheus Exporter For JIRA [![Build Status](https://travis-ci.org/AndreyVMarkelov/jira-prometheus-exporter.svg?branch=master)](https://travis-ci.org/AndreyVMarkelov/jira-prometheus-exporter)
+# Prometheus Exporter For Jira [![Build Status](https://travis-ci.org/AndreyVMarkelov/jira-prometheus-exporter.svg?branch=master)](https://travis-ci.org/AndreyVMarkelov/jira-prometheus-exporter)
 
-This is JIRA plugin which provides endpoint to expose JIRA metrics to Prometheus.
+This is a Jira plugin which provides an endpoint to expose Jira metrics to Prometheus.
 
 For more information the documentation [Prometheus Exporter For Jira](https://github.com/AndreyVMarkelov/jira-prometheus-exporter/wiki/Prometheus-Exporter-For-JIRA).
 

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -734,7 +734,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "JIRA Issues",
+      "title": "Jira Issues",
       "titleSize": "h6"
     },
     {
@@ -997,7 +997,7 @@
             "#d44a3a"
           ],
           "datasource": "${DS_PROMETHEUS}",
-          "description": "The total issues in JIRA",
+          "description": "The total issues in Jira",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1423,6 +1423,6 @@
     ]
   },
   "timezone": "",
-  "title": "JIRA",
+  "title": "Jira",
   "version": 30
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>atlassian-plugin</packaging>
 
     <name>Prometheus Exporter For Jira</name>
-    <description>This plugin for Atlassian JIRA provides endpoint to export metrics to prometheus.</description>
+    <description>This plugin for Atlassian Jira provides an endpoint to export metrics to Prometheus.</description>
 
     <organization>
         <name>Andrey Markelov</name>


### PR DESCRIPTION
Changes the referenced case of `JIRA` to Jira to officially align to Atlassian branding changes announced in 2017.

https://community.atlassian.com/t5/Feedback-Forum-articles/A-new-look-for-Atlassian/ba-p/638077

Thanks for the plugin, we use it with great success!